### PR TITLE
adding default AWS SDK credential resolution to connector

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,7 +236,7 @@ Please check the AWS Lambda Go same code [here](https://github.com/uber/athenadr
 
 #### Use `athenadriver` Config For Authentication
 
-When environment variable `AWS_SDK_LOAD_CONFIG` is NOT set, you can pass valid (NOT dummy) `region`, `accessID`, `secretAccessKey` into `athenadriver.NewDefaultConfig()`, in addition to `outputBucket`.
+When environment variable `AWS_SDK_LOAD_CONFIG` is NOT set, you may explicitly define crednetials by passing valid valid (NOT dummy) `accessID`, `secretAccessKey`, `region`, and `outputBucket` into `athenadriver.NewDefaultConfig()`.
 
 The sample code below ensure `AWS_SDK_LOAD_CONFIG` is not set, then pass four valid parameters into `NewDefaultConfig()`:
 

--- a/README.md
+++ b/README.md
@@ -271,7 +271,7 @@ If environment variable `AWS_SDK_LOAD_CONFIG` is NOT set and credentials are not
 
 `Region` and `OutputBucket` bucket still need to be explictly defined.
 
-The sample code below ensure `AWS_SDK_LOAD_CONFIG` is not set, then creates a athenadriver config with OutputBucket and Region values set.
+The sample code below ensures `AWS_SDK_LOAD_CONFIG` is not set, then creates a athenadriver config with OutputBucket and Region values set.
 
 ```go
 // To use AWS SDK Default Credentials

--- a/README.md
+++ b/README.md
@@ -236,7 +236,7 @@ Please check the AWS Lambda Go same code [here](https://github.com/uber/athenadr
 
 #### Use `athenadriver` Config For Authentication
 
-When environment variable `AWS_SDK_LOAD_CONFIG` is NOT set, you may explicitly define crednetials by passing valid valid (NOT dummy) `accessID`, `secretAccessKey`, `region`, and `outputBucket` into `athenadriver.NewDefaultConfig()`.
+When environment variable `AWS_SDK_LOAD_CONFIG` is NOT set, you may explicitly define credentials by passing valid (NOT dummy) `accessID`, `secretAccessKey`, `region`, and `outputBucket` into `athenadriver.NewDefaultConfig()`.
 
 The sample code below ensure `AWS_SDK_LOAD_CONFIG` is not set, then pass four valid parameters into `NewDefaultConfig()`:
 

--- a/README.md
+++ b/README.md
@@ -267,7 +267,7 @@ with AthenaDriver Config: 123
 The full code is here at [examples/auth.go](https://github.com/uber/athenadriver/tree/master/examples/auth.go).
 
 #### Use AWS SDK Default Credentials Resolution for Authentication
-If environment variable `AWS_SDK_LOAD_CONFIG` is NOT set and credentials are not supplied in the athenadriver configuration, the AWS SDK will lookup credentials using its default methodology described here: https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html#specifying-credentials.
+If environment variable `AWS_SDK_LOAD_CONFIG` is NOT set and credentials are not supplied in the `athenadriver` configuration, the AWS SDK will look up credentials using its default methodology described here: https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html#specifying-credentials.
 
 `Region` and `OutputBucket` bucket still need to be explictly defined.
 

--- a/README.md
+++ b/README.md
@@ -236,7 +236,7 @@ Please check the AWS Lambda Go same code [here](https://github.com/uber/athenadr
 
 #### Use `athenadriver` Config For Authentication
 
-When environment variable `AWS_SDK_LOAD_CONFIG` is NOT set, you need to pass valid(NOT dummy) `region`, `accessID`, `secretAccessKey` into `athenadriver.NewDefaultConfig()`, in addition to `outputBucket`.
+When environment variable `AWS_SDK_LOAD_CONFIG` is NOT set, you can pass valid (NOT dummy) `region`, `accessID`, `secretAccessKey` into `athenadriver.NewDefaultConfig()`, in addition to `outputBucket`.
 
 The sample code below ensure `AWS_SDK_LOAD_CONFIG` is not set, then pass four valid parameters into `NewDefaultConfig()`:
 
@@ -265,6 +265,36 @@ with AthenaDriver Config: 123
 ```
 
 The full code is here at [examples/auth.go](https://github.com/uber/athenadriver/tree/master/examples/auth.go).
+
+#### Use AWS SDK Default Credentials Resolution for Authentication
+If environment variable `AWS_SDK_LOAD_CONFIG` is NOT set and credentials are not supplied in the athenadriver configuration, the AWS SDK will lookup credentials using its default methodology described here: https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html#specifying-credentials.
+
+`Region` and `OutputBucket` bucket still need to be explictly defined.
+
+The sample code below ensure `AWS_SDK_LOAD_CONFIG` is not set, then creates a athenadriver config with OutputBucket and Region values set.
+
+```go
+// To use AWS SDK Default Credentials
+func useAthenaDriverConfigForAuth() {
+	os.Unsetenv("AWS_SDK_LOAD_CONFIG")
+	// 1. Set OutputBucket and Region in Driver Config.
+	conf := drv.NewNoOpsConfig()
+	conf.SetOutputBucket(secret.OutputBucketDev)
+	conf.SetRegion(secret.Region)
+
+	// 2. Open Connection.
+	db, _ := sql.Open(drv.DriverName, conf.Stringify())
+	// 3. Query and print results
+	var i int
+	_ = db.QueryRow("SELECT 123").Scan(&i)
+	println("with AthenaDriver Config:", i)
+}
+```
+The sample output:
+
+```go
+with AthenaDriver Config: 123
+```
 
 ### Full Support of All Data Types 
 

--- a/go/connector.go
+++ b/go/connector.go
@@ -84,7 +84,7 @@ func (c *SQLConnector) Connect(ctx context.Context) (driver.Conn, error) {
 		} else {
 			awsAthenaSession, err = session.NewSession(&aws.Config{})
 		}
-	} else if c.config.GetSecretAccessKey() != "" {
+	} else if c.config.GetAccessID() != "" {
 		staticCredentials := credentials.NewStaticCredentials(c.config.GetAccessID(),
 			c.config.GetSecretAccessKey(),
 			c.config.GetSessionToken())

--- a/go/connector.go
+++ b/go/connector.go
@@ -84,7 +84,7 @@ func (c *SQLConnector) Connect(ctx context.Context) (driver.Conn, error) {
 		} else {
 			awsAthenaSession, err = session.NewSession(&aws.Config{})
 		}
-	} else {
+	} else if c.config.GetSecretAccessKey() != "" {
 		staticCredentials := credentials.NewStaticCredentials(c.config.GetAccessID(),
 			c.config.GetSecretAccessKey(),
 			c.config.GetSessionToken())
@@ -93,6 +93,10 @@ func (c *SQLConnector) Connect(ctx context.Context) (driver.Conn, error) {
 			Credentials: staticCredentials,
 		}
 		awsAthenaSession, err = session.NewSession(awsConfig)
+	} else {
+		awsAthenaSession, err = session.NewSession(&aws.Config{
+			Region: aws.String(c.config.GetRegion()),
+		})
 	}
 	if err != nil {
 		c.tracer.Scope().Counter(DriverName + ".failure.sqlconnector.newsession").Inc(1)

--- a/go/connector_test.go
+++ b/go/connector_test.go
@@ -139,6 +139,22 @@ func TestSQLConnector_Connect_NewSession_AWS_SDK_LOAD_CONFIG_false(t *testing.T)
 	assert.NotNil(t, conn)
 }
 
+func TestSQLConnector_Connect_NewSession_Credentials(t *testing.T) {
+	testConf := NewNoOpsConfig()
+	_ = testConf.SetRegion("ap-southeast-1")
+	_ = testConf.SetAccessID("testid")
+	_ = testConf.SetSecretAccessKey("testkey")
+	connector := &SQLConnector{
+		config: testConf,
+		tracer: NewDefaultObservability(testConf),
+	}
+
+	conn, err := connector.Connect(context.Background())
+
+	assert.Nil(t, err)
+	assert.NotNil(t, conn)
+}
+
 func TestSQLConnector_Driver(t *testing.T) {
 	testConf := NewNoOpsConfig()
 	connector := &SQLConnector{


### PR DESCRIPTION
# Summary
As described in https://github.com/uber/athenadriver/issues/44, athenadriver currently only supports CLI or explicit Authentication. This PR adds AWS SDK authentication as described here: https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html#specifying-credentials.
# Details
- Updated `Connector.Connect()`. If `AWS_SDK_LOAD_CONFIG` is not set and Access lD is empty, the `aws.Config` used to start the sdk session will only contain the region, as defined in the `athenadriver.Config`
- Updated Readme.MD
- Added a test for the case where credentials are explicitly set. Cases where `AWS_SDK_LOAD_CONFIG` is set and cases where neither `AWS_SDK_LOAD_CONFIG` nor credentials are explicitly set already exist. I wanted to enhance test cases to assert the values of the `aws.Config` are created by `Connector.Connect()`, however the internals of `aws.Config` are only accessible through function that alters the values making the test invalid. Tests using mocks was not feasible as the code that we are attempting to test would have to be mocked itself, defeating the purpose of the test.